### PR TITLE
Add MICROLITE_SPIRAM to support ESP32 with SPIRAM

### DIFF
--- a/.github/workflows/build_esp32.yml
+++ b/.github/workflows/build_esp32.yml
@@ -1,4 +1,3 @@
-
 name: ESP32
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule
@@ -6,10 +5,10 @@ on:
   push:
   pull_request:
     paths-ignore:
-      - 'examples/**'
-      - 'README.md'
-      - 'ci/*unix*.sh'
-      - '.github/workflows/build_unix.yml'
+      - "examples/**"
+      - "README.md"
+      - "ci/*unix*.sh"
+      - ".github/workflows/build_unix.yml"
 
 jobs:
   tensorflow_micropython_esp32_build:
@@ -34,16 +33,16 @@ jobs:
           echo "esp-idf-commit=$IDF_COMMIT" >> $GITHUB_ENV
           TFLM_COMMIT=$(git submodule status tensorflow | awk '{print ($1)}')
           echo "tflm-commit=$TFLM_COMMIT" >> $GITHUB_ENV
-#      - name: Cache esp-idf
-#        id: cache-esp-idf
-#        uses: actions/cache@v2
-#        env:
-#          cache-name: cache-esp-idf
-#        with:
-#          path: ./esp-idf
-#          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.esp-idf-commit }}
+      #      - name: Cache esp-idf
+      #        id: cache-esp-idf
+      #        uses: actions/cache@v2
+      #        env:
+      #          cache-name: cache-esp-idf
+      #        with:
+      #          path: ./esp-idf
+      #          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.esp-idf-commit }}
       - name: Setup IDF
-#        if: steps.cache-esp-idf.outputs.cache-hit != 'true'
+        #        if: steps.cache-esp-idf.outputs.cache-hit != 'true'
         run: |
           source ./micropython/tools/ci.sh && ci_esp32_setup_helper v4.3.1
       - name: Cache tflm
@@ -69,9 +68,9 @@ jobs:
           cd ./tensorflow
 
           ../micropython-modules/microlite/prepare-tflm-esp.sh
-          
+
       - name: Build micropython cross compiler
-        run:  |
+        run: |
           source ./esp-idf/export.sh
           cd ./micropython
           echo "make -C mpy-cross V=1 clean all"
@@ -79,10 +78,10 @@ jobs:
       - name: Build standard non-psram 4MB Flash firmware
         run: |
           source ./esp-idf/export.sh
-          
+
           echo "cd ./boards/esp32/MICROLITE"
           cd ./boards/esp32/MICROLITE
-          
+
           echo "Building MICROLITE"
           rm -rf builds
           idf.py clean build
@@ -98,10 +97,10 @@ jobs:
       - name: Build with psram support and 16MB Flash firmware
         run: |
           source ./esp-idf/export.sh
-          
+
           echo "cd ./boards/esp32/MICROLITE_SPIRAM_16M"
           cd ./boards/esp32/MICROLITE_SPIRAM_16M
-          
+
           echo "Building MICROLITE_SPIRAM_16M"
           rm -rf build
           idf.py clean build
@@ -114,3 +113,23 @@ jobs:
             boards/esp32/MICROLITE_SPIRAM_16M/build/bootloader/bootloader.bin
             boards/esp32/MICROLITE_SPIRAM_16M/build/partition_table/partition-table.bin
             boards/esp32/MICROLITE_SPIRAM_16M/build/micropython.bin
+
+      - name: Build with psram support
+        run: |
+          source ./esp-idf/export.sh
+
+          echo "cd ./boards/esp32/MICROLITE_SPIRAM"
+          cd ./boards/esp32/MICROLITE_SPIRAM
+
+          echo "Building MICROLITE_SPIRAM"
+          rm -rf build
+          idf.py clean build
+
+      - name: Archive ESP32-MICROLITE-SPIRAM firmware
+        uses: actions/upload-artifact@v2
+        with:
+          name: microlite-spiram-esp32-firmware
+          path: |
+            boards/esp32/MICROLITE_SPIRAM/build/bootloader/bootloader.bin
+            boards/esp32/MICROLITE_SPIRAM/build/partition_table/partition-table.bin
+            boards/esp32/MICROLITE_SPIRAM/build/micropython.bin

--- a/boards/esp32/MICROLITE_SPIRAM/CMakeLists.txt
+++ b/boards/esp32/MICROLITE_SPIRAM/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Top-level cmake file for building MicroPython on ESP32.
+# Nothing in here needs to be customised, it will work for any board.
+
+cmake_minimum_required(VERSION 3.12)
+
+# Set the location of MicroPython, the esp32 port, and the board directory.
+get_filename_component(PROJECT_DIR "../../.." ABSOLUTE)
+set(MICROPY_PORT_DIR ${PROJECT_DIR}/micropython/ports/esp32)
+get_filename_component(MICROPY_BOARD_DIR "." ABSOLUTE)
+
+message (STATUS "PROJECT_DIR=${PROJECT_DIR}")
+message (STATUS "MICROPY_PORT_DIR=${MICROPY_PORT_DIR}")
+message (STATUS "MICROPY_BOARD_DIR=${MICROPY_BOARD_DIR}")
+
+# Define the output sdkconfig so it goes in the build directory.
+set(SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig)
+
+# Include board config; this is expected to set SDKCONFIG_DEFAULTS (among other options).
+include(${MICROPY_BOARD_DIR}/mpconfigboard.cmake)
+
+# Concatenate all sdkconfig files into a combined one for the IDF to use.
+file(WRITE ${CMAKE_BINARY_DIR}/sdkconfig.combined.in "")
+foreach(SDKCONFIG_DEFAULT ${SDKCONFIG_DEFAULTS})
+    file(READ ${SDKCONFIG_DEFAULT} CONTENTS)
+    file(APPEND ${CMAKE_BINARY_DIR}/sdkconfig.combined.in "${CONTENTS}")
+endforeach()
+configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
+set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
+
+# Include main IDF cmake file and define the project.
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(micropython)

--- a/boards/esp32/MICROLITE_SPIRAM/custom-partitions.csv
+++ b/boards/esp32/MICROLITE_SPIRAM/custom-partitions.csv
@@ -1,0 +1,10 @@
+# Notes: the offset of the partition table itself is set in
+# $ESPIDF/components/partition_table/Kconfig.projbuild and the
+# offset of the factory/ota_0 partition is set in makeimg.py
+# I needed to increase the size of the app partition to fit the tensorflow microlite library
+# There is 1/2 as much data partition as with standard micropython on esp32 4MiB.
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,  0x6000,
+phy_init, data, phy,     0xf000,  0x1000,
+factory,  app,  factory, 0x10000, 0x280000,
+vfs,      data, fat,     0x300000, 0x100000,

--- a/boards/esp32/MICROLITE_SPIRAM/main/CMakeLists.txt
+++ b/boards/esp32/MICROLITE_SPIRAM/main/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Include MicroPython ESP32 component.
+
+get_filename_component(CURRENT_DIR "." ABSOLUTE)
+
+message(STATUS "microlite/main/cmake: CURRENT_DIR=${CURRENT_DIR}")
+
+get_filename_component(MICROPY_DIR "../../../../micropython" ABSOLUTE)
+
+
+message (STATUS "microlite/main/cmake: MICROPY_DIR=${MICROPY_DIR}")
+
+set(PROJECT_DIR ${MICROPY_DIR}/ports/esp32)
+include(${PROJECT_DIR}/main/CMakeLists.txt)

--- a/boards/esp32/MICROLITE_SPIRAM/mpconfigboard.cmake
+++ b/boards/esp32/MICROLITE_SPIRAM/mpconfigboard.cmake
@@ -1,0 +1,20 @@
+set (IDF_TARGET esp32)
+
+set(SDKCONFIG_DEFAULTS
+    ${MICROPY_PORT_DIR}/boards/sdkconfig.base
+    ${MICROPY_PORT_DIR}/boards/sdkconfig.ble
+    ${MICROPY_PORT_DIR}/boards/sdkconfig.240mhz
+    ${MICROPY_PORT_DIR}/boards/sdkconfig.spiram
+    ${MICROPY_BOARD_DIR}/sdkconfig.partition
+
+)
+
+message (STATUS "mpconfigboard.cmake: PROJECT_DIR=${PROJECT_DIR}")
+
+set(USER_C_MODULES
+    ${PROJECT_DIR}/micropython-modules/micropython.cmake
+)
+
+if(NOT MICROPY_FROZEN_MANIFEST)
+    set(MICROPY_FROZEN_MANIFEST ${MICROPY_PORT_DIR}/boards/manifest.py)
+endif()

--- a/boards/esp32/MICROLITE_SPIRAM/mpconfigboard.h
+++ b/boards/esp32/MICROLITE_SPIRAM/mpconfigboard.h
@@ -1,0 +1,2 @@
+#define MICROPY_HW_BOARD_NAME "ESP32 module (microlite-spiram)"
+#define MICROPY_HW_MCU_NAME "ESP32"

--- a/boards/esp32/MICROLITE_SPIRAM/sdkconfig.partition
+++ b/boards/esp32/MICROLITE_SPIRAM/sdkconfig.partition
@@ -1,0 +1,6 @@
+#CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
+#CONFIG_ESPTOOLPY_FLASHFREQ_40M=y
+#CONFIG_ESPTOOLPY_FLASHSIZE_2MB=y
+CONFIG_PARTITION_TABLE_CUSTOM=y
+# move back up from micropython/ports/esp32 to the main project source code
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="../../../boards/esp32/MICROLITE/custom-partitions.csv"


### PR DESCRIPTION
I'm using a TinyPICO board which has SPIRAM - this makes it work on it.