### PR TITLE
Enabled support for ESP-NN optimizations

### DIFF
--- a/micropython-modules/microlite/micropython.cmake
+++ b/micropython-modules/microlite/micropython.cmake
@@ -28,35 +28,11 @@ if (PICO_SDK_PATH)
   set(MICROLITE_PLATFORM "RP2")
 endif()
 
-if(IDF_TARGET STREQUAL "esp32")
-  set(MICROLITE_PLATFORM "ESP32")
-endif()
-
-if(IDF_TARGET STREQUAL "esp32s2")
-  set(MICROLITE_PLATFORM "ESP32S2")
-endif()
-
-if(IDF_TARGET STREQUAL "esp32s3")
-  set(MICROLITE_PLATFORM "ESP32S3")
-endif()
-
-if(IDF_TARGET STREQUAL "esp32c3")
-  set(MICROLITE_PLATFORM "ESP32C3")
-endif()
+include (${CMAKE_CURRENT_LIST_DIR}/micropython_esp.cmake)
 
 get_filename_component(TENSORFLOW_DIR ${PROJECT_DIR}/../../../tensorflow ABSOLUTE)
 
 add_library(microlite INTERFACE)
-
-if (MICROLITE_PLATFORM STREQUAL "ESP32" OR 
-    MICROLITE_PLATFORM STREQUAL "ESP32S3" OR
-    MICROLITE_PLATFORM STREQUAL "ESP32C3" OR 
-    MICROLITE_PLATFORM STREQUAL "ESP32S2")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
-
-endif()
 
 # needed when we have custom/specialized kernels.
 # add_custom_command(
@@ -65,72 +41,80 @@ endif()
 #     DEPENDS MICROPY_FORCE_BUILD
 # )
 
-if (MICROLITE_PLATFORM STREQUAL "ESP32" OR 
-            MICROLITE_PLATFORM STREQUAL "ESP32S3" OR 
-            MICROLITE_PLATFORM STREQUAL "ESP32C3" OR 
-            MICROLITE_PLATFORM STREQUAL "ESP32S2")
-    set (TF_MICROLITE_LOG 
-        ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/debug_log.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/micro_time.cpp
-    )
-endif()
-
 if (MICROLITE_PLATFORM STREQUAL "RP2")
-    set (TF_MICROLITE_LOG 
+    set (TF_MICROLITE_LOG
         ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/cortex_m_generic/debug_log.cpp
         ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/cortex_m_generic/micro_time.cpp
     )
 endif()
 
+if (CONFIG_IDF_TARGET)
+    set(TF_ESP_DIR "${CMAKE_CURRENT_LIST_DIR}/../../tflm_esp_kernels/components/tflite-lib")
+    set(TF_LITE_DIR "${TF_ESP_DIR}/tensorflow/lite")
+    set(TF_MICRO_DIR "${TF_LITE_DIR}/micro")
+    set(TF_MICROLITE_LOG
+            ${TF_MICRO_DIR}/debug_log.cc
+            ${TF_MICRO_DIR}/micro_time.cc
+    )
+else()
+    set(TF_LITE_DIR "${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite")
+    set(TF_MICRO_DIR "${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro")
+endif()
 
-
-
-# copied from https://github.com/espressif/tflite-micro-esp-examples/blob/master/components/tflite-lib/CMakeLists.txt
-# commit: 2ef35273160643b172ce76078c0c95c71d528842
-set(TF_LITE_DIR "${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite")
-set(TF_MICRO_DIR "${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro")
-
-# lite c 
+# lite c
 
 file(GLOB TF_LITE_C_SRCS
           "${TF_LITE_DIR}/c/*.cpp"
           "${TF_LITE_DIR}/c/*.c")
 
-# lite core/api 
-
+# lite core/api
+if (CONFIG_IDF_TARGET)
+file(GLOB TF_LITE_API_SRCS
+          "${TF_LITE_DIR}/core/api/*.cc"
+          "${TF_LITE_DIR}/core/api/*.c"
+          "${TF_LITE_DIR}/core/c/*.cc"
+          "${TF_LITE_DIR}/core/c/*.c")
+else()
 file(GLOB TF_LITE_API_SRCS
           "${TF_LITE_DIR}/core/api/*.cpp"
           "${TF_LITE_DIR}/core/api/*.c")
+endif()
 
-# lite experimental 
+# lite experimental
 
 file(GLOB TF_LITE_MICROFRONTEND_SRCS
           "${TF_LITE_DIR}/experimental/microfrontend/lib/*.c"
+          "${TF_LITE_DIR}/experimental/microfrontend/lib/*.cc"
           "${TF_LITE_DIR}/experimental/microfrontend/lib/*.cpp")
 
-# lite kernels 
+# lite kernels
 
 file(GLOB TF_LITE_KERNELS_SRCS
           "${TF_LITE_DIR}/kernels/*.c"
           "${TF_LITE_DIR}/kernels/*.cpp"
+          "${TF_LITE_DIR}/kernels/*.cc"
           "${TF_LITE_DIR}/kernels/internal/*.c"
           "${TF_LITE_DIR}/kernels/internal/*.cpp"
+          "${TF_LITE_DIR}/kernels/internal/*.cc"
           "${TF_LITE_DIR}/kernels/internal/reference/*.c"
           "${TF_LITE_DIR}/kernels/internal/reference/*.cpp"
+          "${TF_LITE_DIR}/kernels/internal/reference/*.cc"
           )
 
-# lite schema 
+# lite schema
 file(GLOB TF_LITE_SCHEMA_SRCS
           "${TF_LITE_DIR}/schema/*.c"
+          "${TF_LITE_DIR}/schema/*.cc"
           "${TF_LITE_DIR}/schema/*.cpp")
 
-# micro 
+# micro
 
 file(GLOB TF_MICRO_SRCS
           "${TF_MICRO_DIR}/*.c"
+          "${TF_MICRO_DIR}/*.cc"
           "${TF_MICRO_DIR}/*.cpp")
 
-          
+
 # logs are platform specific and added seperately
 
 list(REMOVE_ITEM TF_MICRO_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/debug_log.cpp)
@@ -139,24 +123,28 @@ list(REMOVE_ITEM TF_MICRO_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/mi
 # arena allocator
 file(GLOB TF_MICRO_ARENA_ALLOCATOR_SRCS
           "${TF_MICRO_DIR}/arena_allocator/*.cpp"
+          "${TF_MICRO_DIR}/arena_allocator/*.cc"
           "${TF_MICRO_DIR}/arena_allocator/*.c")
 
-# micro kernels 
+# micro kernels
 
 file(GLOB TF_MICRO_KERNELS_SRCS
           "${TF_MICRO_DIR}/kernels/*.c"
+          "${TF_MICRO_DIR}/kernels/*.cc"
           "${TF_MICRO_DIR}/kernels/*.cpp")
 
-# micro memory_planner 
+# micro memory_planner
 
 file(GLOB TF_MICRO_MEMORY_PLANNER_SRCS
           "${TF_MICRO_DIR}/memory_planner/*.cpp"
+          "${TF_MICRO_DIR}/memory_planner/*.cc"
           "${TF_MICRO_DIR}/memory_planner/*.c")
 
 # tflite_bridge
 
 file(GLOB TF_MICRO_TFLITE_BRIDGE_SRCS
           "${TF_MICRO_DIR}/tflite_bridge/*.cpp"
+          "${TF_MICRO_DIR}/tflite_bridge/*.cc"
           "${TF_MICRO_DIR}/tflite_bridge/*.c")
 
 set (BOARD_ADDITIONAL_SRCS "")
@@ -171,7 +159,7 @@ if (MICROLITE_PLATFORM STREQUAL "RP2")
     list(REMOVE_ITEM TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/pooling.cpp)
     list(REMOVE_ITEM TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/softmax.cpp)
     list(REMOVE_ITEM TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/svdf.cpp)
-    
+
     list(APPEND TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/cmsis_nn/add.cpp)
     list(APPEND TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/cmsis_nn/conv.cpp)
     list(APPEND TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/cmsis_nn/depthwise_conv.cpp)
@@ -180,7 +168,7 @@ if (MICROLITE_PLATFORM STREQUAL "RP2")
     list(APPEND TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/cmsis_nn/pooling.cpp)
     list(APPEND TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/cmsis_nn/softmax.cpp)
     list(APPEND TF_MICRO_KERNELS_SRCS ${CMAKE_CURRENT_LIST_DIR}/tflm/tensorflow/lite/micro/kernels/cmsis_nn/svdf.cpp)
-    
+
     set (CMSIS_NN_SRCS
 
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/ActivationFunctions/arm_relu6_s8.c
@@ -243,7 +231,7 @@ if (MICROLITE_PLATFORM STREQUAL "RP2")
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/SoftmaxFunctions/arm_softmax_s8.c
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/SoftmaxFunctions/arm_softmax_s8_s16.c
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/SoftmaxFunctions/arm_softmax_u8.c
-        
+
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/SVDFunctions
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/SVDFunctions/arm_svdf_s8.c
         ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/cmsis_nn/Source/SVDFunctions/arm_svdf_state_s16_s8.c
@@ -279,13 +267,47 @@ target_sources(microlite INTERFACE
 
 else()
 
+if (CONFIG_IDF_TARGET)
+    set(tfmicro_kernels_dir ${TF_MICRO_DIR}/kernels)
+    # set(tfmicro_nn_kernels_dir
+    #     ${tfmicro_kernels_dir}/)
 
-target_sources(microlite INTERFACE
+    # remove sources which will be provided by esp_nn
+    list(REMOVE_ITEM TF_MICRO_KERNELS_SRCS
+        "${tfmicro_kernels_dir}/add.cc"
+        "${tfmicro_kernels_dir}/conv.cc"
+        "${tfmicro_kernels_dir}/depthwise_conv.cc"
+        "${tfmicro_kernels_dir}/fully_connected.cc"
+        "${tfmicro_kernels_dir}/mul.cc"
+        "${tfmicro_kernels_dir}/pooling.cc"
+        "${tfmicro_kernels_dir}/softmax.cc"
+    )
+
+    # tflm wrappers for ESP_NN
+    FILE(GLOB ESP_NN_WRAPPERS
+        "${tfmicro_kernels_dir}/esp_nn/*.cc")
+endif()
+
 #   microlite micropython module sources
+set (MICROLITE_PYTHON_SRCS
     ${CMAKE_CURRENT_LIST_DIR}/tensorflow-microlite.c
     ${CMAKE_CURRENT_LIST_DIR}/audio_frontend.c
-    ${CMAKE_CURRENT_LIST_DIR}/openmv-libtf.cpp
     ${CMAKE_CURRENT_LIST_DIR}/micropython-error-reporter.cpp
+)
+
+if (CONFIG_IDF_TARGET)
+    list(APPEND MICROLITE_PYTHON_SRCS
+        ${CMAKE_CURRENT_LIST_DIR}/openmv-libtf-updated.cpp
+    )
+else()
+    list(APPEND MICROLITE_PYTHON_SRCS
+        ${CMAKE_CURRENT_LIST_DIR}/openmv-libtf.cpp
+    )
+endif()
+
+target_sources(microlite INTERFACE
+    # micro_python sources for tflite
+    ${MICROLITE_PYTHON_SRCS}
 
     # tf lite sources
     ${TF_LITE_C_SRCS}
@@ -302,8 +324,27 @@ target_sources(microlite INTERFACE
     ${TF_MICRO_TFLITE_BRIDGE_SRCS}
 
     ${TF_MICROLITE_LOG}
+    ${ESP_NN_SRCS} # include esp-nn sources for Espressif chipsets
+    ${ESP_NN_WRAPPERS} # add tflm wrappers for ESP_NN
+    )
 
-)
+if (CONFIG_IDF_TARGET)
+    set(signal_srcs
+        ${TF_ESP_DIR}/signal/micro/kernels/rfft.cc
+        ${TF_ESP_DIR}/signal/micro/kernels/window.cc
+        ${TF_ESP_DIR}/signal/src/kiss_fft_wrappers/kiss_fft_float.cc
+        ${TF_ESP_DIR}/signal/src/kiss_fft_wrappers/kiss_fft_int16.cc
+        ${TF_ESP_DIR}/signal/src/kiss_fft_wrappers/kiss_fft_int32.cc
+        ${TF_ESP_DIR}/signal/src/rfft_float.cc
+        ${TF_ESP_DIR}/signal/src/rfft_int16.cc
+        ${TF_ESP_DIR}/signal/src/rfft_int32.cc
+        ${TF_ESP_DIR}/signal/src/window.cc
+    )
+    target_sources(microlite INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/python_ops_resolver.cc
+        ${signal_srcs}
+    )
+endif()
 
 endif()
 
@@ -350,11 +391,22 @@ target_compile_options(microlite INTERFACE
     -Wno-error=maybe-uninitialized
 )
 
-
-
+else()
+if (CONFIG_IDF_TARGET)
+target_include_directories(microlite INTERFACE
+    ${TF_ESP_DIR}
+    ${TF_ESP_DIR}/third_party/kissfft
+    ${TF_ESP_DIR}/third_party/kissfft/tools
+    ${TF_ESP_DIR}/third_party/flatbuffers/include
+    ${TF_ESP_DIR}/third_party/gemmlowp
+    ${TF_ESP_DIR}/third_party/ruy
+    ${TF_ESP_DIR}/signal/micro/kernels
+    ${TF_ESP_DIR}/signal/src
+    ${TF_ESP_DIR}/signal/src/kiss_fft_wrappers
+    ${ESP_NN_INC}
+)
 else()
 
-# ESP32 
 target_include_directories(microlite INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tflm
@@ -364,13 +416,20 @@ target_include_directories(microlite INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/gemmlowp
     ${CMAKE_CURRENT_LIST_DIR}/tflm/third_party/ruy
 )
+endif()
 
 target_compile_definitions(microlite INTERFACE
     MODULE_MICROLITE_ENABLED=1
     TF_LITE_STATIC_MEMORY=1
     TF_LITE_MCU_DEBUG_LOG
     NDEBUG
-)
+    )
+if (CONFIG_IDF_TARGET)
+    target_compile_definitions(microlite INTERFACE
+        ESP_NN=1 # enables esp_nn optimizations if those sources are added
+        CONFIG_NN_OPTIMIZED=1 # use Optimized vs ansi code from ESP-NN
+    )
+endif()
 
 target_compile_options(microlite INTERFACE
     -Wno-error
@@ -388,7 +447,4 @@ target_compile_options(microlite INTERFACE
 
 endif()
 
-
-
 target_link_libraries(usermod INTERFACE microlite)
-

--- a/micropython-modules/microlite/micropython.cmake
+++ b/micropython-modules/microlite/micropython.cmake
@@ -28,6 +28,13 @@ if (PICO_SDK_PATH)
   set(MICROLITE_PLATFORM "RP2")
 endif()
 
+if(NOT MICROPY_DIR)
+    get_filename_component(MICROPY_DIR ${PROJECT_DIR}/../.. ABSOLUTE)
+endif()
+
+# `py.cmake` for `micropy_gather_target_properties` macro usage
+include(${MICROPY_DIR}/py/py.cmake)
+
 include (${CMAKE_CURRENT_LIST_DIR}/micropython_esp.cmake)
 
 get_filename_component(TENSORFLOW_DIR ${PROJECT_DIR}/../../../tensorflow ABSOLUTE)
@@ -448,3 +455,4 @@ target_compile_options(microlite INTERFACE
 endif()
 
 target_link_libraries(usermod INTERFACE microlite)
+micropy_gather_target_properties(microlite)

--- a/micropython-modules/microlite/micropython_esp.cmake
+++ b/micropython-modules/microlite/micropython_esp.cmake
@@ -1,0 +1,67 @@
+# File to contain all the source list for Espressif boards to build
+
+if(IDF_TARGET STREQUAL "esp32")
+  set(MICROLITE_PLATFORM "ESP32")
+endif()
+
+if(IDF_TARGET STREQUAL "esp32s2")
+  set(MICROLITE_PLATFORM "ESP32S2")
+endif()
+
+if(IDF_TARGET STREQUAL "esp32s3")
+  set(MICROLITE_PLATFORM "ESP32S3")
+endif()
+
+if(IDF_TARGET STREQUAL "esp32c3")
+  set(MICROLITE_PLATFORM "ESP32C3")
+endif()
+
+if (MICROLITE_PLATFORM STREQUAL "ESP32" OR
+    MICROLITE_PLATFORM STREQUAL "ESP32S3" OR
+    MICROLITE_PLATFORM STREQUAL "ESP32C3" OR
+    MICROLITE_PLATFORM STREQUAL "ESP32S2")
+
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
+    set(ESP_NN_DIR "${CMAKE_CURRENT_LIST_DIR}/../../tflm_esp_kernels/components/esp-nn")
+    set(ESP_NN_SRCS
+        "${ESP_NN_DIR}/src/activation_functions/esp_nn_relu_ansi.c"
+        "${ESP_NN_DIR}/src/basic_math/esp_nn_add_ansi.c"
+        "${ESP_NN_DIR}/src/basic_math/esp_nn_mul_ansi.c"
+        "${ESP_NN_DIR}/src/convolution/esp_nn_conv_ansi.c"
+        "${ESP_NN_DIR}/src/convolution/esp_nn_conv_opt.c"
+        "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_ansi.c"
+        "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_opt.c"
+        "${ESP_NN_DIR}/src/fully_connected/esp_nn_fully_connected_ansi.c"
+        "${ESP_NN_DIR}/src/softmax/esp_nn_softmax_ansi.c"
+        "${ESP_NN_DIR}/src/softmax/esp_nn_softmax_opt.c"
+        "${ESP_NN_DIR}/src/pooling/esp_nn_avg_pool_ansi.c"
+        "${ESP_NN_DIR}/src/pooling/esp_nn_max_pool_ansi.c"
+    )
+    if(CONFIG_IDF_TARGET_ESP32S3)
+        list(APPEND ESP_NN_SRCS
+            "${ESP_NN_DIR}/src/common/esp_nn_common_functions_esp32s3.S"
+            "${ESP_NN_DIR}/src/common/esp_nn_multiply_by_quantized_mult_esp32s3.S"
+            "${ESP_NN_DIR}/src/common/esp_nn_multiply_by_quantized_mult_ver1_esp32s3.S"
+            "${ESP_NN_DIR}/src/activation_functions/esp_nn_relu_s8_esp32s3.S"
+            "${ESP_NN_DIR}/src/basic_math/esp_nn_add_s8_esp32s3.S"
+            "${ESP_NN_DIR}/src/basic_math/esp_nn_mul_s8_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_conv_esp32s3.c"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s8_esp32s3.c"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_conv_s16_mult8_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_conv_s8_mult8_1x1_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_conv_s16_mult4_1x1_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_conv_s8_filter_aligned_input_padded_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s8_mult1_3x3_padded_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s16_mult1_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s16_mult1_3x3_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s16_mult1_3x3_no_pad_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s16_mult8_3x3_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s16_mult4_esp32s3.S"
+            "${ESP_NN_DIR}/src/convolution/esp_nn_depthwise_conv_s16_mult8_esp32s3.S"
+            "${ESP_NN_DIR}/src/fully_connected/esp_nn_fully_connected_s8_esp32s3.S"
+            "${ESP_NN_DIR}/src/pooling/esp_nn_max_pool_s8_esp32s3.S"
+            "${ESP_NN_DIR}/src/pooling/esp_nn_avg_pool_s8_esp32s3.S")
+    endif()
+    set(ESP_NN_INC ${ESP_NN_DIR}/include ${ESP_NN_DIR}/src/common)
+endif()

--- a/micropython-modules/microlite/openmv-libtf-updated.cpp
+++ b/micropython-modules/microlite/openmv-libtf-updated.cpp
@@ -1,0 +1,116 @@
+/* This file is part of the OpenMV project.
+ * Copyright (c) 2013-2019 Ibrahim Abdelkader <iabdalkader@openmv.io> & Kwabena W. Agyeman <kwagyeman@openmv.io>
+ * This work is licensed under the MIT license, see the file LICENSE for details.
+ */
+
+// Copied and modified for using with newer tflite-micro sources
+
+#include "python_ops_resolver.h"
+#include "tensorflow/lite/micro/tflite_bridge/micro_error_reporter.h"
+#include "tensorflow/lite/micro/micro_interpreter.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+#include "tensorflow-microlite.h"
+#include "openmv-libtf.h"
+#include "micropython-error-reporter.h"
+#include <stdio.h>
+
+extern "C" {
+    STATIC microlite::MicropythonErrorReporter micro_error_reporter;
+/*
+ Return the index'th tensor
+ */
+    TfLiteTensor *libtf_interpreter_get_input_tensor(microlite_interpreter_obj_t *microlite_interpreter, mp_uint_t index) {
+
+        tflite::MicroInterpreter *interpreter = (tflite::MicroInterpreter *)microlite_interpreter->tf_interpreter;
+
+        return interpreter->input((size_t)index);
+    }
+
+    TfLiteTensor *libtf_interpreter_get_output_tensor(microlite_interpreter_obj_t *microlite_interpreter, mp_uint_t index) {
+
+        tflite::MicroInterpreter *interpreter = (tflite::MicroInterpreter *)microlite_interpreter->tf_interpreter;
+
+        return interpreter->output((size_t)index);
+    }
+
+    // static int libtf_align_tensor_arena(uint8_t **tensor_arena, size_t *tensor_arena_size)
+    // {
+    //      tflite::ErrorReporter *error_reporter = &micro_error_reporter;
+
+    //      error_reporter->Report("Performing Alignment");
+    //      uint8_t alignment = ((uint8_t) (*tensor_arena)) % 16;
+
+    //      if (alignment) {
+
+    //          unsigned int fix = 16 - alignment;
+
+    //          if ((*tensor_arena_size) < fix) {
+    //              return 1;
+    //          }
+
+    //          (*tensor_arena) += fix;
+    //          (*tensor_arena_size) -= fix;
+    //      }
+
+    //      return 0;
+    //  }
+
+
+    int libtf_interpreter_init(microlite_interpreter_obj_t *microlite_interpreter) {
+
+        tflite::ErrorReporter *error_reporter = &micro_error_reporter;
+
+        const tflite::Model *model = tflite::GetModel(microlite_interpreter->model_data->items);
+
+//        if (model->version() != TFLITE_SCHEMA_VERSION) {
+//            error_reporter->Report("Model provided is schema version is not equal to supported version!");
+//            return 1;
+//        }
+
+        // if (libtf_align_tensor_arena((uint8_t **)microlite_interpreter->tensor_area->items, &microlite_interpreter->tensor_area->len)) {
+        //      error_reporter->Report("Align failed!");
+        //      return 1;
+        //  }
+
+
+        microlite_interpreter->tf_error_reporter = (mp_obj_t)error_reporter;
+        microlite_interpreter->tf_model = (mp_obj_t)model;
+
+
+        // tflite::MicroAllocator *allocator = tflite::MicroAllocator::Create(
+        //     (uint8_t*)microlite_interpreter->tensor_area->items,
+        //     microlite_interpreter->tensor_area->len, error_reporter);
+
+
+        tflite::PythonOpsResolver op_resolver;
+        tflite::MicroInterpreter *interpreter = new tflite::MicroInterpreter(model,
+                                             op_resolver,
+                                             (uint8_t*)microlite_interpreter->tensor_area->items,
+                                             microlite_interpreter->tensor_area->len);
+
+        if (interpreter->AllocateTensors() != kTfLiteOk) {
+            MicroPrintf("AllocateTensors() failed!");
+            return 1;
+        }
+
+        microlite_interpreter->tf_interpreter = (mp_obj_t)interpreter;
+
+        return 0;
+    }
+
+    int libtf_interpreter_invoke(microlite_interpreter_obj_t *microlite_interpreter)
+    {
+        tflite::MicroInterpreter *interpreter = (tflite::MicroInterpreter *)microlite_interpreter->tf_interpreter;
+
+        mp_call_function_1(microlite_interpreter->input_callback, microlite_interpreter);
+
+        if (interpreter->Invoke() != kTfLiteOk) {
+            MicroPrintf("Invoke() failed!");
+            return 1;
+        }
+
+        mp_call_function_1(microlite_interpreter->output_callback, microlite_interpreter);
+        return 0;
+    }
+}

--- a/micropython-modules/microlite/python_ops_resolver.cc
+++ b/micropython-modules/microlite/python_ops_resolver.cc
@@ -1,0 +1,123 @@
+/* Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "python_ops_resolver.h"
+
+#include "tensorflow/lite/micro/kernels/micro_ops.h"
+
+namespace tflite {
+
+PythonOpsResolver::PythonOpsResolver() {
+  // Please keep this list of Builtin Operators in alphabetical order.
+  AddAbs();
+  AddAdd();
+  AddAddN();
+  AddArgMax();
+  AddArgMin();
+  AddAssignVariable();
+  AddAveragePool2D();
+  AddBatchToSpaceNd();
+  AddBroadcastArgs();
+  AddBroadcastTo();
+  AddCallOnce();
+  AddCast();
+  AddCeil();
+  AddCircularBuffer();
+  AddConcatenation();
+  AddConv2D();
+  AddCos();
+  AddCumSum();
+  AddDepthToSpace();
+  AddDepthwiseConv2D();
+  AddDequantize();
+  AddDetectionPostprocess();
+  AddDiv();
+  AddElu();
+  AddEqual();
+  AddEthosU();
+  AddExp();
+  AddExpandDims();
+  AddFill();
+  AddFloor();
+  AddFloorDiv();
+  AddFloorMod();
+  AddFullyConnected();
+  AddGather();
+  AddGatherNd();
+  AddGreater();
+  AddGreaterEqual();
+  AddHardSwish();
+  AddIf();
+  AddL2Normalization();
+  AddL2Pool2D();
+  AddLeakyRelu();
+  AddLess();
+  AddLessEqual();
+  AddLog();
+  AddLogicalAnd();
+  AddLogicalNot();
+  AddLogicalOr();
+  AddLogistic();
+  AddLogSoftmax();
+  AddMaxPool2D();
+  AddMaximum();
+  AddMean();
+  AddMinimum();
+  AddMirrorPad();
+  AddMul();
+  AddNeg();
+  AddNotEqual();
+  AddPack();
+  AddPad();
+  AddPadV2();
+  AddPrelu();
+  AddQuantize();
+  AddReadVariable();
+  AddReduceMax();
+  AddRelu();
+  AddRelu6();
+  AddReshape();
+  AddResizeBilinear();
+  AddResizeNearestNeighbor();
+  AddRound();
+  AddRsqrt();
+  AddSelectV2();
+  AddShape();
+  AddSin();
+  AddSlice();
+  AddSoftmax();
+  AddSpaceToBatchNd();
+  AddSpaceToDepth();
+  AddSplit();
+  AddSplitV();
+  AddSqrt();
+  AddSquare();
+  AddSquaredDifference();
+  AddSqueeze();
+  AddStridedSlice();
+  AddSub();
+  AddSum();
+  AddSvdf();
+  AddTanh();
+  AddTranspose();
+  AddTransposeConv();
+  AddUnidirectionalSequenceLSTM();
+  AddUnpack();
+  AddVarHandle();
+  AddWhile();
+  AddZerosLike();
+}
+
+}  // namespace tflite

--- a/micropython-modules/microlite/python_ops_resolver.h
+++ b/micropython-modules/microlite/python_ops_resolver.h
@@ -1,0 +1,36 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_MICRO_PYTHON_OPS_RESOLVER_H_
+#define TENSORFLOW_LITE_MICRO_PYTHON_OPS_RESOLVER_H_
+
+#include "tensorflow/lite/micro/compatibility.h"
+#include "tensorflow/lite/micro/micro_mutable_op_resolver.h"
+
+namespace tflite {
+
+// PythonOpsResolver is used to register all the Ops for the TFLM Python
+// interpreter. This is ok since code size is not a concern from Python and
+// the goal is to be able to run any model supported by TFLM in a flexible way
+class PythonOpsResolver : public MicroMutableOpResolver<200> {
+ public:
+  PythonOpsResolver();
+
+ private:
+  TF_LITE_REMOVE_VIRTUAL_DELETE
+};
+
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_MICRO_PYTHON_OPS_RESOLVER_H_


### PR DESCRIPTION
Following changes were done:
  1. Duplicated `openmv-libtf.cpp` to `openmv-libtf-updated.cpp` and used python_ops_resolver instead of all_ops_resolver which has been removed from latest `tflite-micro` sources.
  2. Added `python_ops_resolver` sources from `tflite-micro`
  3. Declutter: Create separate .cmake for `esp` specfic boards
  4. Added ESP-NN sources to `micropython.cmake` and `micropython_esp.cmake`